### PR TITLE
Feature/calculate cidr addresses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ip-range",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "An IP range parser",
   "main": "range.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "node test.js"
   },
-  "repository" : {
+  "repository": {
     "type": "git",
     "url": "http://github.com/sberan/ip-range.git"
   },
@@ -15,5 +15,8 @@
     "range"
   ],
   "author": "Sam Beran",
-  "license": "BSD"
+  "license": "BSD",
+  "dependencies": {
+    "ip-subnet-calculator": "^1.0.2"
+  }
 }

--- a/range.js
+++ b/range.js
@@ -26,6 +26,10 @@ exports.range = varArgs(function(specs) {
       errors.push("Hyphenated values not allowed in first or second octet. ");
     }
 
+    if(octets[0].indexOf('*') != -1 || octets[1].indexOf('*') != -1) {
+      errors.push("Wildcards are not allowed in the first or second octet. ");
+    }
+
     if(octets.length != 4) {
       errors.push("IP must contain 4 octets, contained: " + octets.length);
     }

--- a/range.js
+++ b/range.js
@@ -1,3 +1,5 @@
+var ipCalc = require('ip-subnet-calculator');
+
 /**
  * returns a function which will apply a list of args to the
  * given function as if they were passed as an array
@@ -8,13 +10,21 @@ function varArgs(fn) {
       args = Array.prototype.slice.call(arguments);
     }
     return fn(args);
-  }
+  };
+}
+
+function mapCalculatorResponseToCIDRNotation(maskObj) {
+  return maskObj.ipLowStr + '/' + maskObj.prefixSize.toString();
 }
 
 exports.range = varArgs(function(specs) {
   var errors = [];
   var parsedSpecs = specs.map(function(spec) {
     var octets = spec.split(".");
+
+    if(octets[0].indexOf('-') != -1 || octets[1].indexOf('-') != -1) {
+      errors.push("Hyphenated values not allowed in first or second octet. ");
+    }
 
     if(octets.length != 4) {
       errors.push("IP must contain 4 octets, contained: " + octets.length);
@@ -40,11 +50,34 @@ exports.range = varArgs(function(specs) {
     });
   });
 
-  
+  var inetAddresses = [];
+  var fromAddress, toAddress, masks;
+  if (errors.length === 0) {
+    parsedSpecs.forEach(function(parsedSpec) {
+      var prefix = parsedSpec[0][0].toString() + '.' + parsedSpec[1][0] + '.';
+       // * in the 4th octet, any variation in the third results in a contiguous block of IPs
+      if (parsedSpec[3][0] === 0 && parsedSpec[3][1] === 255) {
+        fromAddress = prefix + parsedSpec[2][0].toString() + '.0';
+        toAddress = prefix + parsedSpec[2][1].toString() + '.255';
+        masks = ipCalc.calculate(fromAddress, toAddress);
+        Array.prototype.push.apply(inetAddresses, masks.map(mapCalculatorResponseToCIDRNotation));
+      } else {
+        // Otherwise we need to treat each value within the range of the 3rd octet as its
+        // own range represented by its own set of inet address/mask combinations
+        for (var j=parsedSpec[2][0];j<=parsedSpec[2][1];j++) {
+          fromAddress = prefix + j + '.' + parsedSpec[3][0];
+          toAddress = prefix + j + '.' + parsedSpec[3][1];
+          masks = ipCalc.calculate(fromAddress, toAddress);
+          Array.prototype.push.apply(inetAddresses, masks.map(mapCalculatorResponseToCIDRNotation));
+        }
+      }
+    });
+  }
   return {
-    valid: errors.length == 0,
+    valid: errors.length === 0,
     errors: errors,
     entries: parsedSpecs,
+    inetAddresses: inetAddresses,
     contains: varArgs(function(specs) {
       if(errors.length) {
         return false;
@@ -52,10 +85,10 @@ exports.range = varArgs(function(specs) {
       var range = exports.range(specs),
           specOctets, parsedOctets, found, i, j, k;
       for(i = 0; i < range.entries.length; i++) {
-        var specOctets = range.entries[i];
-        var found = false;
+        specOctets = range.entries[i];
+        found = false;
         for(j = 0; j < parsedSpecs.length; j++) {
-          var parsedOctets = parsedSpecs[j];
+          parsedOctets = parsedSpecs[j];
           var matches = true;
           for(k = 0; k < 4; k++) {
             if(specOctets[k][0] < parsedOctets[k][0] || specOctets[k][1] > parsedOctets[k][1]) {

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 var ip = require('./');
-
+var util = require('util');
 
 var range = ip.range('192.168.0.1');
 
@@ -8,6 +8,8 @@ assert(range.valid, range.errors);
 assert(range.contains('192.168.0.1'));
 assert(!range.contains('192.168.0.0'));
 
+assert.equal(ip.range("0-255.1.1.1").errors, "Hyphenated values not allowed in first or second octet. ");
+assert.equal(ip.range("1.0-255.1.1").errors, "Hyphenated values not allowed in first or second octet. ");
 assert.equal(ip.range("1.2.3").errors, "IP must contain 4 octets, contained: 3");
 assert.equal(ip.range("1.2.3.a").errors, "error in octet 4, invalid octet spec: 'a'");
 assert.equal(ip.range("1.2.3.266").errors, "error in octet 4, octet range out of bounds: '266'");
@@ -18,6 +20,34 @@ assert(!ip.range('1.0.1.*').contains('1.0.0.10'));
 assert(ip.range('1.2.3.4-10').contains('1.2.3.4', '1.2.3.10'));
 assert(ip.range('1.2.3.5', '1.2.3.4').contains('1.2.3.4', '1.2.3.5'));
 
-// Must add tests for inetAddresses property!
-assert(false);
+// Handy tool for generating test data: http://www.ipaddressguide.com/cidr#range
+// If the range finishes with wildcards, we should have
+// one cidr notation range with a netmask.
+assert(ip.range('1.0.1.*').inetAddresses.length === 1);
+assert(ip.range('1.0.1.*').inetAddresses[0] === '1.0.1.0/24');
 
+assert(ip.range('1.0.*.*').inetAddresses.length === 1);
+assert(ip.range('1.0.*.*').inetAddresses[0] === '1.0.0.0/16');
+
+// Ranges that don't align on powers of 2 boundaries will require
+// multiple cidr notation ranges to specify.
+
+// Our package leans upon the ip-subnet-calculator module
+// to do the heavy lifting of calculating cidr notation ranges.
+// The current version over-specifies some ranges, but not so
+// much as to cause us preformance problems.  We can leave
+// eliminating redundant ranges as a possible opportunity for
+// improvement.
+assert(ip.range('1.2.3.4-10').inetAddresses.length === 3);
+assert(ip.range('1.2.3.4-10').inetAddresses.indexOf('1.2.3.4/30') !== -1);
+assert(ip.range('1.2.3.4-10').inetAddresses.indexOf('1.2.3.8/31') !== -1);
+
+// Non-contiguous ranges need multiple cidr notation ranges
+// to specify as well
+assert(ip.range('1.2.0-5.0').inetAddresses.length === 6);
+assert(ip.range('1.2.0-5.0').inetAddresses.indexOf('1.2.0.0/32') !== -1);
+assert(ip.range('1.2.0-5.0').inetAddresses.indexOf('1.2.1.0/32') !== -1);
+assert(ip.range('1.2.0-5.0').inetAddresses.indexOf('1.2.2.0/32') !== -1);
+assert(ip.range('1.2.0-5.0').inetAddresses.indexOf('1.2.3.0/32') !== -1);
+assert(ip.range('1.2.0-5.0').inetAddresses.indexOf('1.2.4.0/32') !== -1);
+assert(ip.range('1.2.0-5.0').inetAddresses.indexOf('1.2.5.0/32') !== -1);

--- a/test.js
+++ b/test.js
@@ -2,9 +2,9 @@ var assert = require('assert');
 var ip = require('./');
 
 
-var range = ip.range('192.168.0.1')
+var range = ip.range('192.168.0.1');
 
-assert(range.valid, range.errors)
+assert(range.valid, range.errors);
 assert(range.contains('192.168.0.1'));
 assert(!range.contains('192.168.0.0'));
 
@@ -17,4 +17,7 @@ assert(ip.range('1.*.0.*').contains('1.2.0.10'));
 assert(!ip.range('1.0.1.*').contains('1.0.0.10'));
 assert(ip.range('1.2.3.4-10').contains('1.2.3.4', '1.2.3.10'));
 assert(ip.range('1.2.3.5', '1.2.3.4').contains('1.2.3.4', '1.2.3.5'));
+
+// Must add tests for inetAddresses property!
+assert(false);
 

--- a/test.js
+++ b/test.js
@@ -8,14 +8,20 @@ assert(range.valid, range.errors);
 assert(range.contains('192.168.0.1'));
 assert(!range.contains('192.168.0.0'));
 
+// No wildcards in first or second octets
+assert.equal(ip.range("*.1.1.1").errors, "Wildcards are not allowed in the first or second octet. ");
+assert.equal(ip.range("1.*.1.1").errors, "Wildcards are not allowed in the first or second octet. ");
+
+// No ranges in first or second octets
 assert.equal(ip.range("0-255.1.1.1").errors, "Hyphenated values not allowed in first or second octet. ");
 assert.equal(ip.range("1.0-255.1.1").errors, "Hyphenated values not allowed in first or second octet. ");
+
+
 assert.equal(ip.range("1.2.3").errors, "IP must contain 4 octets, contained: 3");
 assert.equal(ip.range("1.2.3.a").errors, "error in octet 4, invalid octet spec: 'a'");
 assert.equal(ip.range("1.2.3.266").errors, "error in octet 4, octet range out of bounds: '266'");
 
 
-assert(ip.range('1.*.0.*').contains('1.2.0.10'));
 assert(!ip.range('1.0.1.*').contains('1.0.0.10'));
 assert(ip.range('1.2.3.4-10').contains('1.2.3.4', '1.2.3.10'));
 assert(ip.range('1.2.3.5', '1.2.3.4').contains('1.2.3.4', '1.2.3.5'));
@@ -23,11 +29,11 @@ assert(ip.range('1.2.3.5', '1.2.3.4').contains('1.2.3.4', '1.2.3.5'));
 // Handy tool for generating test data: http://www.ipaddressguide.com/cidr#range
 // If the range finishes with wildcards, we should have
 // one cidr notation range with a netmask.
-assert(ip.range('1.0.1.*').inetAddresses.length === 1);
-assert(ip.range('1.0.1.*').inetAddresses[0] === '1.0.1.0/24');
+assert.equal(ip.range('1.0.1.*').inetAddresses.length, 1);
+assert.equal(ip.range('1.0.1.*').inetAddresses[0], '1.0.1.0/24');
 
-assert(ip.range('1.0.*.*').inetAddresses.length === 1);
-assert(ip.range('1.0.*.*').inetAddresses[0] === '1.0.0.0/16');
+assert.equal(ip.range('1.0.*.*').inetAddresses.length, 1);
+assert.equal(ip.range('1.0.*.*').inetAddresses[0], '1.0.0.0/16');
 
 // Ranges that don't align on powers of 2 boundaries will require
 // multiple cidr notation ranges to specify.
@@ -38,16 +44,17 @@ assert(ip.range('1.0.*.*').inetAddresses[0] === '1.0.0.0/16');
 // much as to cause us preformance problems.  We can leave
 // eliminating redundant ranges as a possible opportunity for
 // improvement.
-assert(ip.range('1.2.3.4-10').inetAddresses.length === 3);
-assert(ip.range('1.2.3.4-10').inetAddresses.indexOf('1.2.3.4/30') !== -1);
-assert(ip.range('1.2.3.4-10').inetAddresses.indexOf('1.2.3.8/31') !== -1);
+assert.equal(ip.range('1.2.3.4-10').inetAddresses.length, 3);
+assert.notEqual(ip.range('1.2.3.4-10').inetAddresses.indexOf('1.2.3.4/30'), -1);
+assert.notEqual(ip.range('1.2.3.4-10').inetAddresses.indexOf('1.2.3.8/31'), -1);
+//  Additionally, the result currently includes 1.2.3.10/32, which is redundant
 
 // Non-contiguous ranges need multiple cidr notation ranges
 // to specify as well
-assert(ip.range('1.2.0-5.0').inetAddresses.length === 6);
-assert(ip.range('1.2.0-5.0').inetAddresses.indexOf('1.2.0.0/32') !== -1);
-assert(ip.range('1.2.0-5.0').inetAddresses.indexOf('1.2.1.0/32') !== -1);
-assert(ip.range('1.2.0-5.0').inetAddresses.indexOf('1.2.2.0/32') !== -1);
-assert(ip.range('1.2.0-5.0').inetAddresses.indexOf('1.2.3.0/32') !== -1);
-assert(ip.range('1.2.0-5.0').inetAddresses.indexOf('1.2.4.0/32') !== -1);
-assert(ip.range('1.2.0-5.0').inetAddresses.indexOf('1.2.5.0/32') !== -1);
+assert.equal(ip.range('1.2.0-5.0').inetAddresses.length, 6);
+assert.notEqual(ip.range('1.2.0-5.0').inetAddresses.indexOf('1.2.0.0/32'), -1);
+assert.notEqual(ip.range('1.2.0-5.0').inetAddresses.indexOf('1.2.1.0/32'), -1);
+assert.notEqual(ip.range('1.2.0-5.0').inetAddresses.indexOf('1.2.2.0/32'), -1);
+assert.notEqual(ip.range('1.2.0-5.0').inetAddresses.indexOf('1.2.3.0/32'), -1);
+assert.notEqual(ip.range('1.2.0-5.0').inetAddresses.indexOf('1.2.4.0/32'), -1);
+assert.notEqual(ip.range('1.2.0-5.0').inetAddresses.indexOf('1.2.5.0/32'), -1);


### PR DESCRIPTION
Adds the inetAddress property to the return object, which should contain an array of CIDR notation values that fit the ranges specified in our custom notation format.  While testing I discovered that the response sometimes overspecifies the range, returning the occasional redundant cidr address.  For example:

1.2.3.4-10 can be represented as 2 CIDR notation ranges:
- 1.2.3.4/30
- 1.2.3.8/31

but the underlying ip-subnet-calculator module returns three: The mentioned 2, and an additional, redundant
range: 1.2.3.10/32 (which is wholly contained in 1.2.3.8/31)

We can take it as an opportunity for improvement to tighten up the ip-subnet-calculator to return the minimum necessary CIDR notation values.
