### PR TITLE
prevent error if string only has 1 or 2 octets

### DIFF
--- a/range.js
+++ b/range.js
@@ -22,16 +22,16 @@ exports.range = varArgs(function(specs) {
   var parsedSpecs = specs.map(function(spec) {
     var octets = spec.split(".");
 
-    if(octets[0].indexOf('-') != -1 || octets[1].indexOf('-') != -1) {
-      errors.push("Hyphenated values not allowed in first or second octet. ");
-    }
-
-    if(octets[0].indexOf('*') != -1 || octets[1].indexOf('*') != -1) {
-      errors.push("Wildcards are not allowed in the first or second octet. ");
-    }
-
     if(octets.length != 4) {
       errors.push("IP must contain 4 octets, contained: " + octets.length);
+    } else {
+        if(octets[0].indexOf('-') != -1 || octets[1].indexOf('-') != -1) {
+          errors.push("Hyphenated values not allowed in first or second octet. ");
+        }
+
+        if(octets[0].indexOf('*') != -1 || octets[1].indexOf('*') != -1) {
+          errors.push("Wildcards are not allowed in the first or second octet. ");
+        }
     }
 
     return octets.map(function(octet, i) {

--- a/test.js
+++ b/test.js
@@ -17,7 +17,8 @@ assert.equal(ip.range("0-255.1.1.1").errors, "Hyphenated values not allowed in f
 assert.equal(ip.range("1.0-255.1.1").errors, "Hyphenated values not allowed in first or second octet. ");
 
 
-assert.equal(ip.range("123").errors, "IP must contain 4 octets, contained: 1");
+assert.equal(ip.range("abc").errors[0], "IP must contain 4 octets, contained: 1");
+assert.equal(ip.range("abc").errors[1], "error in octet 1, invalid octet spec: 'abc'");
 assert.equal(ip.range("1.2").errors, "IP must contain 4 octets, contained: 2");
 assert.equal(ip.range("1.2.3").errors, "IP must contain 4 octets, contained: 3");
 assert.equal(ip.range("1.2.3.a").errors, "error in octet 4, invalid octet spec: 'a'");

--- a/test.js
+++ b/test.js
@@ -17,6 +17,8 @@ assert.equal(ip.range("0-255.1.1.1").errors, "Hyphenated values not allowed in f
 assert.equal(ip.range("1.0-255.1.1").errors, "Hyphenated values not allowed in first or second octet. ");
 
 
+assert.equal(ip.range("123").errors, "IP must contain 4 octets, contained: 1");
+assert.equal(ip.range("1.2").errors, "IP must contain 4 octets, contained: 2");
 assert.equal(ip.range("1.2.3").errors, "IP must contain 4 octets, contained: 3");
 assert.equal(ip.range("1.2.3.a").errors, "error in octet 4, invalid octet spec: 'a'");
 assert.equal(ip.range("1.2.3.266").errors, "error in octet 4, octet range out of bounds: '266'");


### PR DESCRIPTION
Code hard fails if passed string doesn't have at least 2 elements after split...

Prevent hard fail...
