### PR TITLE
Feature/check subnet calc for error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ip-range",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "An IP range parser",
   "main": "range.js",
   "scripts": {

--- a/range.js
+++ b/range.js
@@ -63,8 +63,7 @@ exports.range = varArgs(function(specs) {
       if (parsedSpec[3][0] === 0 && parsedSpec[3][1] === 255) {
         fromAddress = prefix + parsedSpec[2][0].toString() + '.0';
         toAddress = prefix + parsedSpec[2][1].toString() + '.255';
-        masks = ipCalc.calculate(fromAddress, toAddress);
-        Array.prototype.push.apply(inetAddresses, masks.map(mapCalculatorResponseToCIDRNotation));
+        checkSubnetMask(fromAddress, toAddress);
       } else {
         // Otherwise we need to treat each value within the range of the 3rd octet as its
         // own range represented by its own set of inet address/mask combinations
@@ -72,10 +71,20 @@ exports.range = varArgs(function(specs) {
           fromAddress = prefix + j + '.' + parsedSpec[3][0];
           toAddress = prefix + j + '.' + parsedSpec[3][1];
           masks = ipCalc.calculate(fromAddress, toAddress);
-          Array.prototype.push.apply(inetAddresses, masks.map(mapCalculatorResponseToCIDRNotation));
+          checkSubnetMask(fromAddress, toAddress);
         }
       }
     });
+
+    function checkSubnetMask(fromAddress, toAddress) {
+      masks = ipCalc.calculate(fromAddress, toAddress);
+      if (masks) {
+        Array.prototype.push.apply(inetAddresses, masks.map(mapCalculatorResponseToCIDRNotation))
+      } else { // ipCalc returns null if error found
+        errors.push("IP subnet mask error, check start and end range: " + fromAddress + " - " + toAddress);
+      }
+    }
+
   }
   return {
     valid: errors.length === 0,

--- a/range.js
+++ b/range.js
@@ -80,8 +80,8 @@ exports.range = varArgs(function(specs) {
       masks = ipCalc.calculate(fromAddress, toAddress);
       if (masks) {
         Array.prototype.push.apply(inetAddresses, masks.map(mapCalculatorResponseToCIDRNotation))
-      } else { // ipCalc returns null if error found
-        errors.push("IP subnet mask error, check start and end range: " + fromAddress + " - " + toAddress);
+      } else { // ip-subnet-calculator returns null if error found
+        errors.push("Internal error in ip-subnet-calculator for ip range value: " + specs);
       }
     }
 

--- a/test.js
+++ b/test.js
@@ -25,8 +25,8 @@ assert.equal(ip.range("1.2.3.a").errors, "error in octet 4, invalid octet spec: 
 assert.equal(ip.range("1.2.3.266").errors, "error in octet 4, octet range out of bounds: '266'");
 
 // check valid subnet
-assert.equal(ip.range("52.123.5-3.*").errors, "IP subnet mask error, check start and end range: 52.123.5.0 - 52.123.3.255");
-assert.equal(ip.range("52.123.3.5-2").errors, "IP subnet mask error, check start and end range: 52.123.3.5 - 52.123.3.2");
+assert.equal(ip.range("52.123.5-3.*").errors, "Internal error in ip-subnet-calculator for ip range value: 52.123.5-3.*");
+assert.equal(ip.range("52.123.3.5-2").errors, "Internal error in ip-subnet-calculator for ip range value: 52.123.3.5-2");
 
 assert(!ip.range('1.0.1.*').contains('1.0.0.10'));
 assert(ip.range('1.2.3.4-10').contains('1.2.3.4', '1.2.3.10'));

--- a/test.js
+++ b/test.js
@@ -24,6 +24,9 @@ assert.equal(ip.range("1.2.3").errors, "IP must contain 4 octets, contained: 3")
 assert.equal(ip.range("1.2.3.a").errors, "error in octet 4, invalid octet spec: 'a'");
 assert.equal(ip.range("1.2.3.266").errors, "error in octet 4, octet range out of bounds: '266'");
 
+// check valid subnet
+assert.equal(ip.range("52.123.5-3.*").errors, "IP subnet mask error, check start and end range: 52.123.5.0 - 52.123.3.255");
+assert.equal(ip.range("52.123.3.5-2").errors, "IP subnet mask error, check start and end range: 52.123.3.5 - 52.123.3.2");
 
 assert(!ip.range('1.0.1.*').contains('1.0.0.10'));
 assert(ip.range('1.2.3.4-10').contains('1.2.3.4', '1.2.3.10'));


### PR DESCRIPTION
We aren't catching errors coming from our subnet calculation so we are hard failing.

If the subnet calculator returns null, it found an error so warn the user.
Add tests.

NOTE: Eventually it might be nice to have the module report the actual error instead of just returning null...
